### PR TITLE
change to Patent Policy 2025

### DIFF
--- a/index.html
+++ b/index.html
@@ -643,7 +643,7 @@
           Patent Policy
         </h2>
         <p>
-          This Working Group operates under the <a href="https://www.w3.org/policies/patent-policy/">W3C Patent Policy</a> (Version of 15 September 2025). To promote the widest adoption of Web standards, W3C seeks to issue Web specifications that can be implemented, according to this policy, on a Royalty-Free basis.
+          This Working Group operates under the <a href="https://www.w3.org/policies/patent-policy/">W3C Patent Policy</a> (Version of 15 May 2025). To promote the widest adoption of Web standards, W3C seeks to issue Web specifications that can be implemented, according to this policy, on a Royalty-Free basis.
 
           For more information about disclosure obligations for this group, please see the <a href="https://www.w3.org/groups/wg/json-ld/ipr">licensing information</a>.
         </p>


### PR DESCRIPTION
Fix #11 (originally https://github.com/w3c/strategy/issues/494#issuecomment-3299419076). This was actually a bug, because the PP URL used in the charter text referred to the 2025 version anyway.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-charter-2025/pull/13.html" title="Last updated on Sep 19, 2025, 4:30 PM UTC (d3c8b00)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-charter-2025/13/c64be62...d3c8b00.html" title="Last updated on Sep 19, 2025, 4:30 PM UTC (d3c8b00)">Diff</a>